### PR TITLE
Remove useless items from result

### DIFF
--- a/src/exchange-side.ts
+++ b/src/exchange-side.ts
@@ -64,9 +64,6 @@ export class CurrencyExchangeSide {
     this.missingBeforeClean = this.value;
 
     const curreniesToClean = this.getCurrenciesToClean(changeCurrency);
-    if (curreniesToClean.length < 2) {
-      return;
-    }
 
     curreniesToClean.forEach((currency) => {
       const amount = this.store[currency];

--- a/src/exchange.spec.ts
+++ b/src/exchange.spec.ts
@@ -452,5 +452,41 @@ describe('CurrencyExchange', () => {
         expect(convertedBuyResult.isComplete()).toEqual(result.isComplete());
       });
     });
+
+    it('Does not contain same item on both sides', () => {
+      const exchange = new CurrencyExchange({
+        buyInventory: {
+          keys: 0,
+          ref: 2,
+          rec: 2,
+          scrap: 1,
+        },
+        sellInventory: {
+          keys: 0,
+          ref: 0,
+          rec: 0,
+          scrap: 2,
+        },
+        price: { keys: 0, metal: 2.55 },
+        keyPrice: 50,
+      });
+
+      const result = exchange.trade();
+
+      expect(result.isComplete()).toBeTruthy();
+      expect(result.buyer).toEqual({
+        keys: 0,
+        ref: 2,
+        rec: 2,
+        scrap: 0,
+      });
+      expect(result.seller).toEqual({
+        keys: 0,
+        ref: 0,
+        rec: 0,
+        scrap: 1,
+      });
+      expect(result.missing).toEqual(0);
+    });
   });
 });


### PR DESCRIPTION
Added new test:

```
const exchange = new CurrencyExchange({
        buyInventory: {
          keys: 0,
          ref: 2,
          rec: 2,
          scrap: 1,
        },
        sellInventory: {
          keys: 0,
          ref: 0,
          rec: 0,
          scrap: 2,
        },
        price: { keys: 0, metal: 2.55 },
        keyPrice: 50,
      });

      const result = exchange.trade();
```

This previously resulted in
- Buyer: `{ keys: 0, ref: 2, rec: 2, scrap: 1 }`
- Seller: `{ keys: 0, ref: 0, rec: 0, scrap: 2 }`

1 scrap should be removed from both sides

New result:
- Buyer: `{ keys: 0, ref: 2, rec: 2, scrap: 0 }`
- Seller: `{ keys: 0, ref: 0, rec: 0, scrap: 1 }`